### PR TITLE
리뷰 내용 적용 PR

### DIFF
--- a/memory_pool_t.cpp
+++ b/memory_pool_t.cpp
@@ -31,12 +31,4 @@ namespace util
 		memory_pool_t& obj = _get_inst();
 		obj._mpool_max_cnt = max_cnt;	
 	}
-
-	void memory_pool_t::_free(base_node_t* node, mpool_cls_type_e cls_type)
-	{
-		memory_pool_t& obj = _get_inst();
-
-		auto find_iter = obj._mpool_cls.find(cls_type);
-		find_iter->second.push(node);
-	}
 }


### PR DESCRIPTION
* 이전에 제안한 리뷰 일부 반영
  * free_basic if constexpr() 정리
    * static_assert(std::is_integral_v) 조건을 컴파일 타임에 검사하는 것으로 수정 (리뷰 7번)
    * 컴파일 타임에 반드시 is_integral이 보장되므로, 에러 핸들링이 필요 없을 것으로 보여, 관련 주석 첨삭
  * 반환 값을 항상 받아야 하는 것으로 보이는 함수들에 [[nodiscard]] 속성 추가 (리뷰 8번)
  * _free() 함수의 node가 반드시 base_node_t를 상속 받는 것을 컴파일 타임에 보장하도록 수정 (리뷰 9번)
    * 위로 인하여 _free()가 템플릿 함수가 되어서, 해당 함수를 cpp 파일에서 h 파일로 이관
    * 다만, _free()의 node가 반드시 base_node_t를 상속해야 하는 것인지는 잘 모르겠어서, 해당 내용은 판단 후 적용 요망

@Olbbemi 