### PR TITLE
수정된 코드에 대한 리뷰 PR

### DIFF
--- a/util_memory_pool.cpp
+++ b/util_memory_pool.cpp
@@ -8,8 +8,7 @@ namespace util
 {
 	long memory_pool_c::_get_osBit()
 	{
-		static long os_byte = sizeof(void*) == 4 ? 4 : 8;
-		return os_byte;
+		return sizeof(void*);
 	}
 
 	long memory_pool_c::_get_pageSize()

--- a/util_memory_pool.h
+++ b/util_memory_pool.h
@@ -35,7 +35,7 @@ namespace util
 	{
 	public:
 		template<typename U, typename... Args>
-		std::shared_ptr<U> alloc(std::string& grp_name, Args... args);
+		std::shared_ptr<U> alloc(const std::string& grp_name, Args... args);
 
 	public:
 		memory_pool_c(std::string& grp_name, int max_cnt);


### PR DESCRIPTION
* _free()에서 컴파일 타임 검사를 진행하여 dynamic_cast -> static_cast가 가능하도록 수정
* std::string& -> const std::string&이 가능한 곳 수정
* 컴파일 타임 검사 에러 내용이 명확하도록 수정
*  _mpool_alloc_cnt 음수 검사 제거 및 디버깅용 assert() 구문 추가
  * _mpool_alloc_cnt가 uint32_t라 0 보다 작을 수 없음
* _get_osBit() 의미가 포인터 크기 측정인 것으로 보여 sizeof(void*)로 수정
* _alloc()에서 uint64_t로 캐스팅 하는 부분을 uintptr_t로 수정
  * 해당 부분은 포인터 크기를 얻어 오려고 하는 것으로 보이는데, _get_osBit()가 따로 빠져 있는 것으로 봐서는 uint64_t로 캐스팅하는 것은 위험해 보임
  * uintptr_t 혹은 _get_osBit()에서 얻어온 값으로 하면 될 것 같기는 한데, 일단은 uintptr_t로 해 봄

@Olbbemi 